### PR TITLE
Bug埋め

### DIFF
--- a/src/app/ui/menu/HelpMenu.java
+++ b/src/app/ui/menu/HelpMenu.java
@@ -26,7 +26,7 @@ public class HelpMenu extends OriginalMenu {
     }
 
     public enum Item {
-        ABOUT("item_about", String.format("%s について", Application.NAME));
+        ABOUT("item_about", "ATMアプソ について");
 
         private String key;
         private String title;


### PR DESCRIPTION
■追加したバグの現象
ヘルプのメニューアイテムが「ATMアプリ　について」　ではなく「ATMアプソ　について」になっている

■発見難易度(想定)
★☆☆☆☆

■特定難易度(想定)
★★☆☆☆