### PR TITLE
【バグ】ユーザーアカウントの文字数に上限値を設定

### DIFF
--- a/src/app/AccountManager.java
+++ b/src/app/AccountManager.java
@@ -64,6 +64,11 @@ public class AccountManager {
      */
     public boolean auth(String username, String password) {
         for (Account account : mAccountList) {
+
+            if(username.length() >= 10){
+                return false;
+            }
+
             // ユーザー名が一致するアカウントでなければ次のアカウントへ飛ぶ
             if (!username.equals(account.getUsername())) {
                 continue;


### PR DESCRIPTION
■追加したバグの現象
ユーザーアカウントに10文字以上入力すると正しいユーザーアカウントでも認証に失敗する

■発見難易度(想定)
★★★★☆

■特定難易度(想定)
★★☆☆☆