### PR TITLE
抜く金額＝＝残高のとき引き出せないバグ（保坂）

### DIFF
--- a/src/app/Account.java
+++ b/src/app/Account.java
@@ -92,12 +92,11 @@ public class Account {
      *         抜く金額が残高より多い場合、-1を返す
      */
     public int decreasesAmount(int amount) throws IllegalArgumentException {
-        if (this.amount < amount) {
-            return -1;
+        if ( this.amount > amount) {
+            this.amount -= amount;
+            return this.amount;
         }
+        return -1;
 
-        this.amount -= amount;
-
-        return this.amount;
     }
 }


### PR DESCRIPTION
■追加したバグの現象
　抜く金額が残高と同額だった場合、引き出しができないバグ。

■発見難易度(想定)
★★☆☆☆

■特定難易度(想定)
★★★★☆