### PR TITLE
Bug: アプリ終了確認ウィンドウがシングルトンになっていない

### DIFF
--- a/src/app/ui/simple/CloseWindowFactory.java
+++ b/src/app/ui/simple/CloseWindowFactory.java
@@ -6,6 +6,6 @@ public class CloseWindowFactory implements WindowFactory {
 
     @Override
     public SimpleWindow getWindow() {
-        return INSTANCE;
+        return new CloseWindow();
     }
 }


### PR DESCRIPTION
■追加したバグの現象
「ATMアプリを終了する」メニューボタンを押してアプリ終了確認ウィンドウを表示したあと、
閉じるボタンで消さない限りメニューボタンを押すたびウィンドウが複数表示されてしまう 

■発見難易度(想定)
★★★☆☆

■特定難易度(想定)
★★★★☆